### PR TITLE
Statutes: Remove mention of Domicil

### DIFF
--- a/statutes.md
+++ b/statutes.md
@@ -2,7 +2,7 @@
 
 Pursuant to Articles 60 et sqq. Civil Code (Zivilgesetzbuch) an association is
 organized under the name „Bitcoin Association Switzerland“ (hereinafter the
-“Association”) with its domicile in Zurich.
+“Association”).
 
 ## Art. 1 Objective
 


### PR DESCRIPTION
This allows for more flexibility.

An explicit provision in the articles of association is not required. Acc. to Swiss civil law, art. 56:
"The seat of the legal entity is located where its administration is carried out, unless its articles of association provide otherwise."

Opening this to replace https://github.com/Bitcoin-Association-Switzerland/bitcoin-association-switzerland/pull/4.

Thanks for the input @folegandroso